### PR TITLE
[Fix] Supports Maximization and Full Screen

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,17 +2,17 @@
     "manifest_version": 1,
     "name": "RoundCornerNCM",
     "slug": "RoundCornerNCM",
-    "version": "0.1.2",
-    "author": "MicroBlock",
-    "description": "网易云窗口圆角。仅Win11。", 
+    "version": "0.1.3",
+    "author": "MicroBlock & vincent1230",
+    "description": "网易云窗口圆角。仅Win11。",
     "betterncm_version": ">=0.2.5",
     "preview": "preview.png",
     "require_restart": true,
-    
+
     "injects": {
-        "Main": [ 
+        "Main": [
             {
-                "file": "plugin.js" 
+                "file": "plugin.js"
             }
         ]
     }

--- a/plugin.js
+++ b/plugin.js
@@ -1,1 +1,16 @@
-betterncm.app.setRoundedCorner(true)
+function isWindowMaximized() {
+    const isWidthMaximized = window.outerWidth === window.screen.availWidth;
+    const isHeightMaximized = window.outerHeight === window.screen.availHeight;
+
+    return isWidthMaximized && isHeightMaximized;
+}
+
+function checkWindowMaximized() {
+    const isMaximized = isWindowMaximized();
+
+    betterncm.app.setRoundedCorner(!isMaximized);
+}
+
+window.addEventListener('resize', checkWindowMaximized);
+
+checkWindowMaximized();

--- a/plugin.js
+++ b/plugin.js
@@ -1,8 +1,12 @@
 function isWindowMaximized() {
-    const isWidthMaximized = window.outerWidth === window.screen.availWidth;
-    const isHeightMaximized = window.outerHeight === window.screen.availHeight;
+    const maximized =
+        window.outerWidth === window.screen.availWidth &&
+        window.outerHeight === window.screen.availHeight;
+    const fullScreen =
+        window.outerWidth === window.screen.width &&
+        window.outerHeight === window.screen.height;
 
-    return isWidthMaximized && isHeightMaximized;
+    return maximized || fullScreen;
 }
 
 function checkWindowMaximized() {


### PR DESCRIPTION
解决了当前所有的 Issues，望采纳

- Windows 11 自带贴靠 / 全屏时禁用窗口圆角逻辑，但该逻辑不处理窗口最大化。因此多显示器或使用第三方任务栏透明软件的情况下，最大化应用显示异常 ( https://github.com/BetterNCM/RoundCornerNCM/issues/4 | https://github.com/BetterNCM/RoundCornerNCM/issues/5 )
  解决方案：当窗口宽高 (outerWidth, outerHeight) 等于当前显示器可用宽高 (availWidth, availHeight) 时，主动设置窗口圆角关闭，并添加监听器监听窗口大小改变。

- 网易云音乐播放 MV 时的全屏是伪全屏，并不是真正提交全屏，而是修改窗口大小与屏幕大小一致。因此操作系统的圆角逻辑失效，导致显示异常 ( https://github.com/BetterNCM/RoundCornerNCM/issues/3 )
  解决方案：当窗口宽高 (outerWidth, outerHeight) 等于当前显示器宽高 (width, height) 一致即全屏时，同样视为最大化。
